### PR TITLE
Fixed a couple of warnings and notices.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -10,9 +10,9 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
         $this->config = get_config('auth/loginlogoutredir');
     }
 
-    function user_authenticated_hook($user, $username, $password) {
+    function user_authenticated_hook(&$user, $username, $password) {
 		global $CFG, $SESSION;
-		if ($CFG->loginredir) {
+		if (isset($CFG->loginredir) && $CFG->loginredir) {
 			$urltogo = $CFG->loginredir;
 			if (true || !isset($SESSION->wantsurl)) {
 				$SESSION->wantsurl = $urltogo;
@@ -30,7 +30,7 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
     function logoutpage_hook() {
 		global $CFG;
 		global $redirect;
-		if ($CFG->logoutredir) {
+		if (isset($CFG->logoutredir) && $CFG->logoutredir) {
 			$redirect = $CFG->logoutredir;
 		}
 		else {


### PR DESCRIPTION
Strict standards: Declaration of auth_plugin_loginlogoutredir::user_authenticated_hook() should be compatible with auth_plugin_base::user_authenticated_hook(&$user, $username, $password)

Also fixed notices when $CFG->loginredirect or $CFG->logoutredirect were not defined in config.php.
