### PR TITLE
Fixed an error displaying in some cases where user is trying to login…

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -9,6 +9,14 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
         $this->authtype = 'loginlogoutredir';
         $this->config = get_config('auth/loginlogoutredir');
     }
+    
+    /*
+     * Must override or an error is printed.
+     * @return boolean False means login was not a success.
+     */
+    function user_login($username, $password) {
+        false;
+    }
 
     function user_authenticated_hook(&$user, $username, $password) {
 		global $CFG, $SESSION;


### PR DESCRIPTION
… with a username that does not exist.

auth_plugin_base:
function user_login($username, $password) {
        print_error('mustbeoveride', 'debug', '', 'user_login()' );
    }
