### PR TITLE
use modern constructor for auth_plugin_loginlogoutredir

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -5,7 +5,7 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
     /**
      * Constructor.
      */
-    function auth_plugin_loginlogoutredir() {
+    function __construct() {
         $this->authtype = 'loginlogoutredir';
         $this->config = get_config('auth/loginlogoutredir');
     }

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2014103000;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2020082500;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2014051200;        // Requires this Moodle version
 $plugin->component = 'auth_loginlogoutredir';      // Full name of the plugin (used for diagnostics)
 $plugin->maturity  = MATURITY_RC;
-$plugin->release   = '1.0 (2014103000)';
+$plugin->release   = '1.0.1 (2020082500)';


### PR DESCRIPTION
Resolves the following deprecation message:

Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; auth_plugin_loginlogoutredir has a deprecated constructor