### PR TITLE
Respect login redirection on confirm of email-based self signup

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,15 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Called when a signup form is about to be rendered. If a login redirection URL is configured then bring the user to
+ * said URL once they have signed up and confirmed their account.
+ */
+function auth_loginlogoutredir_pre_signup_requests() {
+    global $SESSION, $CFG;
+
+    if (isset($CFG->loginredir)) {
+        $SESSION->wantsurl = $CFG->loginredir;
+    }
+}

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2020082500;        // The current plugin version (Date: YYYYMMDDXX)
-$plugin->requires  = 2014051200;        // Requires this Moodle version
+$plugin->version   = 2024081700;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->requires  = 2018051700;        // Requires this Moodle version
 $plugin->component = 'auth_loginlogoutredir';      // Full name of the plugin (used for diagnostics)
 $plugin->maturity  = MATURITY_RC;
-$plugin->release   = '1.0.1 (2020082500)';
+$plugin->release   = '1.0.2 (2024081700)';


### PR DESCRIPTION
In response to issue #9.

This change insures that users creating their account through a (email-based self-registration) signup form will be redirected to the login redirection URL instead of being brought to the Moodle instance’s default location, when they confirm their email. They’ll still see they email confirmation screen, but the "continue" button will point the redirection URL.

I’m bumping the plugin’s requirement to Moodle 3.5, since this change relies on the [pre_signup_requests callback](https://docs.moodle.org/dev/Login_callbacks#pre_signup_requests).