### PR TITLE
Add MOODLE_INTERNAL security check and remove closing PHP tag

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -1,4 +1,29 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Authentication plugin: Login/Logout redirection.
+ *
+ * @package    auth_loginlogoutredir
+ * @copyright  2012 onwards Felipe Carasso (http://carassonet.org)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
 require_once($CFG->libdir.'/authlib.php');
 
 class auth_plugin_loginlogoutredir extends auth_plugin_base {
@@ -46,5 +71,3 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
 		}
     }
 }
-
-?>


### PR DESCRIPTION
Add the required defined('MOODLE_INTERNAL') || die() guard to auth.php to prevent direct script access. Remove the closing ?> tag per Moodle coding guidelines to prevent whitespace injection. Add standard Moodle file header with license boilerplate.