### PR TITLE
Fix missing return statement in user_login()

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -15,7 +15,7 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
      * @return boolean False means login was not a success.
      */
     function user_login($username, $password) {
-        false;
+        return false;
     }
 
     function user_authenticated_hook(&$user, $username, $password) {


### PR DESCRIPTION
The method had a bare expression 'false;' instead of 'return false;', meaning it returned null instead of the expected boolean. This causes incorrect behaviour in PHP 8.x strict contexts.