### PR TITLE
Add explicit public visibility to all methods

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -5,7 +5,7 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
     /**
      * Constructor.
      */
-    function __construct() {
+    public function __construct() {
         $this->authtype = 'loginlogoutredir';
         $this->config = get_config('auth/loginlogoutredir');
     }
@@ -14,11 +14,11 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
      * Must override or an error is printed.
      * @return boolean False means login was not a success.
      */
-    function user_login($username, $password) {
+    public function user_login($username, $password) {
         false;
     }
 
-    function user_authenticated_hook(&$user, $username, $password) {
+    public function user_authenticated_hook(&$user, $username, $password) {
 		global $CFG, $SESSION;
 		if (isset($CFG->loginredir) && $CFG->loginredir) {
 			$urltogo = $CFG->loginredir;
@@ -35,7 +35,7 @@ class auth_plugin_loginlogoutredir extends auth_plugin_base {
 		return true;
     }
 
-    function logoutpage_hook() {
+    public function logoutpage_hook() {
 		global $CFG;
 		global $redirect;
 		if (isset($CFG->logoutredir) && $CFG->logoutredir) {


### PR DESCRIPTION
Add missing 'public' visibility modifier to __construct, user_login, user_authenticated_hook, and logoutpage_hook. Required by Moodle coding guidelines and will be enforced in future PHP versions.